### PR TITLE
fix tracking file after rename: sync rename mode constant

### DIFF
--- a/pkg/watcher.go
+++ b/pkg/watcher.go
@@ -43,7 +43,7 @@ var (
 )
 
 const (
-	renameEvent = 2
+	renameEvent = 0
 	dirCreate   = 3
 	fileCreate  = 4
 	delFile     = -1


### PR DESCRIPTION
The problem was from eBPF we receive rename event as '0' constant, see https://github.com/bookingcom/bpfink/blob/b6882c1daf54b5e3202cf90259c8e868426f8b96/pkg/ebpf/vfs.c#L137
on agent side we assume it is constant of value '2'. Change agent side constant to '0' to be aligned
with eBPF raw event.