### PR TITLE
vfs_write: match not only inode number but dev id of superblock

### DIFF
--- a/pkg/watcher.go
+++ b/pkg/watcher.go
@@ -123,7 +123,7 @@ func (w *Watcher) addInode(event *Event, isdir bool) {
 		return
 	}
 	w.Debug().Msgf("File: %v found for inode", file)
-	fullPath := fmt.Sprintf("%v/%v", file, event.Path)
+	fullPath := path.Join(file, event.Path)
 	event.Path = fullPath
 
 	state := &GenericState{
@@ -139,7 +139,7 @@ func (w *Watcher) addInode(event *Event, isdir bool) {
 	w.Consumers = append(w.Consumers, consumer)
 	// consumer.Init()
 	w.Debug().Msgf("fullPath: %v", event.Path)
-	switch err := w.AddInode(event.Device, event.Path); {
+	switch err := w.AddFile(event.Path); {
 	case err == nil:
 		w.consumers.Store(event.Path, consumer)
 		w.Debug().Str("file", event.Path).Msgf("start watching")
@@ -300,7 +300,7 @@ func (w *Watcher) handleRenamingEvent(event *Event) error {
 			return err
 		}
 
-		targetPath := fmt.Sprintf("%v/%v", targetDir, event.Path)
+		targetPath := path.Join(targetDir, event.Path)
 
 		w.mapping.Store(event.Device, targetPath)
 		w.reverse.Store(targetPath, event.Device)


### PR DESCRIPTION
file is uniquely identified by the (inode, dev) pair. So far we catch a write event
for the file with matched inode. But we also need to verify dev id is also matched
to be sure we catch the event for the right file.

Change trigger: many false positives write events on kafka host where kafka log inode
was equal to one of the /etc files inode (we was monitoring /etc/*).

In order to do that, we put in rules table device id as a value (previously dummy value 1
have been written) and on the ebpf side retrieve dev_id from inode superblock.