### PR TITLE
Add docker image for ebpf library build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM centos:7
+
+# install Go 
+RUN Run wget https://dl.google.com/go/go1.13.3.linux-amd64.tar.gz && \
+    tar -xzf go1.13.3.linux-amd64.tar.gz && \
+    mv go /usr/local
+
+# install bpf build dependancies
+RUN yum install -y epel-release && \
+    yum update -y && \
+    yum groupinstall -y "Development tools" && \
+    yum install -y elfutils-libelf-devel cmake3 git bison flex ncurses-devel && \
+    yum install -y luajit luajit-devel  # for Lua support && \
+    yum install -y centos-release-scl && \
+    yum-config-manager --enable rhel-server-rhscl-7-rpms && \
+    yum install -y devtoolset-7 llvm-toolset-7 llvm-toolset-7-llvm-devel llvm-toolset-7-llvm-static llvm-toolset-7-clang-devel && \
+    source scl_source enable devtoolset-7 llvm-toolset-7
+
+RUN mkdir -p /workspace/code/src/github.com && \
+    cd /workspace/code/src/github && \
+    git clone https://github.com/iovisor/bcc.git && \
+    mkdir bcc/build; cd bcc/build && \
+    cmake3 .. && \
+    make && \
+    sudo make install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,44 @@
 FROM centos:7
 
-# install Go 
-RUN Run wget https://dl.google.com/go/go1.13.3.linux-amd64.tar.gz && \
-    tar -xzf go1.13.3.linux-amd64.tar.gz && \
-    mv go /usr/local
-
 # install bpf build dependancies
 RUN yum install -y epel-release && \
     yum update -y && \
     yum groupinstall -y "Development tools" && \
     yum install -y elfutils-libelf-devel cmake3 git bison flex ncurses-devel && \
-    yum install -y luajit luajit-devel  # for Lua support && \
-    yum install -y centos-release-scl && \
+    yum install -y luajit luajit-devel  # for Lua support
+
+# build and install bcc
+RUN yum install -y centos-release-scl && \
     yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum install -y devtoolset-7 llvm-toolset-7 llvm-toolset-7-llvm-devel llvm-toolset-7-llvm-static llvm-toolset-7-clang-devel && \
-    source scl_source enable devtoolset-7 llvm-toolset-7
-
-RUN mkdir -p /workspace/code/src/github.com && \
-    cd /workspace/code/src/github && \
+    source scl_source enable devtoolset-7 llvm-toolset-7 && \
+    mkdir -p /workspace/code/src/github.com && \
+    cd /workspace/code/src/github.com && \
     git clone https://github.com/iovisor/bcc.git && \
-    mkdir bcc/build; cd bcc/build && \
+    mkdir bcc/build && \
+    cd bcc/build && \
     cmake3 .. && \
     make && \
-    sudo make install
+    make install
+
+# enable GCC and Clang permanently for logged in user
+RUN echo "source scl_source enable devtoolset-7 llvm-toolset-7" >> ~/.bashrc
+
+# install kernel-devel for 3.10
+RUN yum install -y kernel-devel
+
+# install kernel-devel for 4.9
+RUN yum install -y http://dl.central.org/dl/linuxdev/fedora25/x86_64/kernel-devel-4.9.3-200.fc25.x86_64.rpm
+
+# install kernel-devel for 4.14
+RUN yum install -y http://dl.central.org/dl/linuxdev/fedora27/x86_64/kernel-devel-4.14.3-300.fc27.x86_64.rpm
+
+# install kernel-devel for 4.18
+RUN yum install -y http://mirror.centos.org/centos/8/BaseOS/x86_64/os/Packages/kernel-devel-4.18.0-193.6.3.el8_2.x86_64.rpm
+
+# install kernel-devel for 4.19
+RUN yum install -y http://dl.central.org/dl/linuxdev/fedora29/x86_64/kernel-devel-4.19.2-300.fc29.x86_64.rpm
+
+# set up build script
+COPY scripts/build.sh .
+CMD ["./build.sh"]

--- a/docs/build.md
+++ b/docs/build.md
@@ -5,7 +5,22 @@ right now building bpfink with eBPF is a multi step process.
 Run the following commands to package eBPF for each kernel major.minor version
 in the future we may support JIT similar to how BCC works. 
 
-### Dependencies
+### eBPF
+
+The recommended way of building eBPF library is using docker. Run following commands in root of this repository:
+
+```bash
+docker build --tag bpfink-kernel . 
+docker run -v "$(pwd):/workspace" bpfink-kernel
+```
+
+This will regenerate `vfs-<kernel-version>.o` files in `pkg/ebpf/` directory using current state of code in `pkg/ebpf/vfs.c`.
+
+If you need to build another version of the kernel, alter `Dockerfile` to install appropriate version of `kernel-devel`
+package and add its number to `scripts/build.sh`.
+
+#### Locally
+
 * LLVM
 * clang
 * kernel-devel
@@ -24,7 +39,7 @@ make -r -C "." -e KERNEL_RELEASE=<kernel_version>
 ```
 The list of supported kernel versions can be found by running the following command inside the container.
 
-`ls /lib/modules/`
+`ls /usr/src/kernels/`
 
 add the updated ELF files to the repo, and push to your branch.
 

--- a/pkg/ebpf/Makefile
+++ b/pkg/ebpf/Makefile
@@ -3,13 +3,13 @@ KERNEL_RELEASE ?= $(shell uname -r)
 INCLUDE_DIR = include
 
 INCLUDES =  -I $(INCLUDE_DIR)
-INCLUDES += -I /lib/modules/$(KERNEL_RELEASE)/build/arch/x86/include
-INCLUDES += -I /lib/modules/$(KERNEL_RELEASE)/build/arch/x86/include/generated
-INCLUDES += -I /lib/modules/$(KERNEL_RELEASE)/build/include
-INCLUDES += -I /lib/modules/$(KERNEL_RELEASE)/build/include/generated/uapi
-INCLUDES += -I /lib/modules/$(KERNEL_RELEASE)/build/arch/x86/include/uapi
-INCLUDES += -I /lib/modules/$(KERNEL_RELEASE)/build/include/uapi
-INCLUDES += -I /lib/modules/$(KERNEL_RELEASE)/build/arch/x86/include/asm/asm.h
+INCLUDES += -I /usr/src/kernels/$(KERNEL_RELEASE)/arch/x86/include
+INCLUDES += -I /usr/src/kernels/$(KERNEL_RELEASE)/arch/x86/include/generated
+INCLUDES += -I /usr/src/kernels/$(KERNEL_RELEASE)/include
+INCLUDES += -I /usr/src/kernels/$(KERNEL_RELEASE)/include/generated/uapi
+INCLUDES += -I /usr/src/kernels/$(KERNEL_RELEASE)/arch/x86/include/uapi
+INCLUDES += -I /usr/src/kernels/$(KERNEL_RELEASE)/include/uapi
+INCLUDES += -I /usr/src/kernels/$(KERNEL_RELEASE)/arch/x86/include/asm/asm.h
 
 MAKEFLAGS += -r
 CC = clang

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e # exit on non-zero exit code
+
+# shellcheck disable=SC2016
+cd workspace/pkg/ebpf ||
+    (
+        echo "ERROR: run inside bpfink folder with following flag to docker:" &&
+            echo 'ERROR: -v $(pwd):/workspace' &&
+            exit 1
+    )
+
+# this command returns non-zero error code, which we want to ignore
+source scl_source enable devtoolset-7 llvm-toolset-7 || true
+
+KERNELS=$(rpm -qa --qf '%{NAME} %{VERSION}-%{RELEASE}.%{ARCH}\n' | grep kernel-devel | cut -d ' ' -f 2)
+KERNELS_SHORT=$(rpm -qa --qf '%{NAME} %{VERSION}\n' | grep kernel-devel | cut -d ' ' -f 2 | cut -d '.' -f -2)
+
+for kernel in 3.10 4.9 4.14 4.18 4.19; do
+    make -r -C "." -e KERNEL_RELEASE="$(echo "$KERNELS" | grep $kernel)"
+    mv -f vfs.o "vfs-$(echo "$KERNELS_SHORT" | grep $kernel)".o
+done


### PR DESCRIPTION
Part of #5 resolution. This PR adds a docker image which can be used to bbuild ebpf library.