### PR TITLE
Consumer to parse sudoers files

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,14 @@ __Main dependencies:__
 
 bpfink Is a set of consumers connected to file system watcher. We are currently using eBPF to watch vfs_write syscalls in the kernel.
 When an event is fired the associated consumer is called, we have currently two
-different consumers for three different use cases:
+different consumers for four different use cases:
 
 - User consumer, watch for the __/passwd__, __/shadow__ file to detect password changes
 (password hash is not logged to avoid offline brute force on leaked logs),
 it also watches for user home directory to detect ssh key injection.
 - Access consumer, just watch __/access.conf__
 - Generic consumer, watches for any existing or new files/directories for any given parent directory
+- Sudoers consumer, watches __/sudoers__ and all files under __/etc/sudoers.d__ directory.
 
 All consumers hold their own states to keep track of changes and diffing. If
 a difference is spotted, the diff is logged to our stdout in json format.

--- a/cfg/agent.toml
+++ b/cfg/agent.toml
@@ -7,6 +7,7 @@ bcc = "pkg/ebpf/vfs.o"
 root = "/"
 access = "/access.conf"
 generic = ["/etc"]
+sudoers = ["/sudoers", "/etc/sudoers.d"]
 
 [consumers.users]
 root = "/"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -121,12 +121,14 @@ func (c Configuration) consumers(db *pkg.AgentDB) (consumers pkg.BaseConsumers) 
 		//get list of files to watch
 		sudoersFiles := c.getListOfFiles(fs, "sudoers")
 		for _, sudoersFile := range sudoersFiles {
-			state := &pkg.SudoersState{
-				SudoersListener: pkg.NewSudoersListener(
-					pkg.SudoersFileOpt(fs, sudoersFile.File, c.logger()),
-				),
+			if !c.fileBelongsToExclusionList(sudoersFile.File) {
+				state := &pkg.SudoersState{
+					SudoersListener: pkg.NewSudoersListener(
+						pkg.SudoersFileOpt(fs, sudoersFile.File, c.logger()),
+					),
+				}
+				consumers = append(consumers, &pkg.BaseConsumer{AgentDB: db, ParserLoader: state})
 			}
-			consumers = append(consumers, &pkg.BaseConsumer{AgentDB: db, ParserLoader: state})
 		}
 	}
 	if len(c.Consumers.Generic) > 0 {

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,11 +11,12 @@ warn level.
 __Structure of the logs:__
 
 As bpfink is trying to be smart during parsing, we are able to log a difference
-of state for dedicated structures. For the moment there's only __3 types of structures/logs__:
+of state for dedicated structures. For the moment there's only __4 types of structures/logs__:
 
 - users
 - access
 - generic
+- sudoers
 
 For each of those the internal structure is bit different, but the way it is logged 
 is the same. Basically, when detecting a change bpfink will logs __3 different information__:
@@ -23,7 +24,7 @@ is the same. Basically, when detecting a change bpfink will logs __3 different i
 - what has been added, under the `add` JSON key
 - what has been deleted, under the `del` JSON key
 - what is the current state, which as a different key depending on the consumer: 
-`users`, `generic`, `access`.
+`users`, `generic`, `access`, `sudoers`.
 
 In order to avoid complex logging logic, if an internal part of a structure has
 changed, this structure is logged both as `add` and `del`, the difference can
@@ -90,9 +91,28 @@ while `root` and `ALL` were
 	"generic":{
 		"current":"","next":"1a25723c4bbfb4ae20b83cbdcfc039e1a4d5f878e0c4b9f58db30478d6f8b6252403ba19d45ade5ea8e3bf65140a8a9b4995674626034f60cc7f405b"
 	},
-	"path":"dynamicPathFile",
+	"file":"dynamicPathFile",
 	"processName":"touch",
+	"user":"root"
 }
 ```
 
 In this example the file dynamicPathFile was created. 
+
+``` json
+{
+	"level": "warn",
+	"add": {
+		"Sudoers": ["root ALL = (ALL:ALL) ALL"]
+	},
+	"del": {
+		"Sudoers": []
+	},
+	"file": "bpfink.sudoers",
+	"processName": "-bash ",
+	"user": "root",
+	"message": "Sudoers file modified"
+}
+```
+
+In the above example the file bpfink.sudoers was modified.

--- a/e2etests/basic_test.go
+++ b/e2etests/basic_test.go
@@ -18,18 +18,18 @@ func TestBPfink(t *testing.T) {
 func testCreateGenericFile(t *testing.T, w *World) {
 	genericFile := path.Join(w.FS.GenericMonitoringDir, "hohoho.txt")
 	f := w.FS.MustCreateFile(t, genericFile)
-	w.BPFink.ExpectGenericEvent(t, Event{
+	w.BPFink.ExpectEvent(t, Event{
 		File:    genericFile,
 		Message: "generic file created",
 	})
 
 	f.WriteString("hello world")
-	w.BPFink.ExpectGenericEvent(t, Event{
+	w.BPFink.ExpectEvent(t, Event{
 		File:    genericFile,
 		Message: "generic file Modified",
 	})
 	w.FS.MustRemoveFile(t, genericFile)
-	w.BPFink.ExpectGenericEvent(t, Event{
+	w.BPFink.ExpectEvent(t, Event{
 		File:    genericFile,
 		Message: "generic file deleted",
 	})
@@ -38,18 +38,18 @@ func testCreateGenericFile(t *testing.T, w *World) {
 func testCreateSudoersDir(t *testing.T, w *World) {
 	sudoersFile := path.Join(w.FS.SudoersDir, "testSudoers")
 	f := w.FS.MustCreateFile(t, sudoersFile)
-	w.BPFink.ExpectSudoersEvent(t, Event{
+	w.BPFink.ExpectEvent(t, Event{
 		File:    sudoersFile,
 		Message: "Sudoers file created",
 	})
 	f.WriteString("root ALL=(ALL) ALL")
-	w.BPFink.ExpectSudoersEvent(t, Event{
+	w.BPFink.ExpectEvent(t, Event{
 		File:    sudoersFile,
 		Message: "Sudoers file modified",
 	})
 
 	w.FS.MustRemoveFile(t, sudoersFile)
-	w.BPFink.ExpectSudoersEvent(t, Event{
+	w.BPFink.ExpectEvent(t, Event{
 		File:    sudoersFile,
 		Message: "Sudoers file deleted",
 	})

--- a/e2etests/basic_test.go
+++ b/e2etests/basic_test.go
@@ -11,6 +11,7 @@ func TestBPfink(t *testing.T) {
 	world := SetUp(t)
 	defer world.TearDown()
 	t.Run("generic file create/modify/delete", world.SubTest(testCreateGenericFile))
+	t.Run("sudoers file create", world.SubTest(testCreateSudoersDir))
 
 }
 
@@ -27,10 +28,29 @@ func testCreateGenericFile(t *testing.T, w *World) {
 		File:    genericFile,
 		Message: "generic file Modified",
 	})
-
 	w.FS.MustRemoveFile(t, genericFile)
 	w.BPFink.ExpectGenericEvent(t, Event{
 		File:    genericFile,
 		Message: "generic file deleted",
+	})
+}
+
+func testCreateSudoersDir(t *testing.T, w *World) {
+	sudoersFile := path.Join(w.FS.SudoersDir, "testSudoers")
+	f := w.FS.MustCreateFile(t, sudoersFile)
+	w.BPFink.ExpectSudoersEvent(t, Event{
+		File:    sudoersFile,
+		Message: "Sudoers file created",
+	})
+	f.WriteString("root ALL=(ALL) ALL")
+	w.BPFink.ExpectSudoersEvent(t, Event{
+		File:    sudoersFile,
+		Message: "Sudoers file modified",
+	})
+
+	w.FS.MustRemoveFile(t, sudoersFile)
+	w.BPFink.ExpectSudoersEvent(t, Event{
+		File:    sudoersFile,
+		Message: "Sudoers file deleted",
 	})
 }

--- a/e2etests/bpfink.go
+++ b/e2etests/bpfink.go
@@ -36,7 +36,7 @@ type baseFileLogRecord struct {
 	User        string `json:"user"`
 }
 
-type genericFileLogRecord struct {
+type genericFileLogRecord struct { // nolint: deadcode, unused
 	baseFileLogRecord
 	Generic struct {
 		Current string
@@ -44,7 +44,7 @@ type genericFileLogRecord struct {
 	}
 }
 
-type sudoersFileLogRecord struct {
+type sudoersFileLogRecord struct { // nolint: deadcode, unused
 	baseFileLogRecord
 	Add struct {
 		Sudoers []string

--- a/e2etests/bpfink.go
+++ b/e2etests/bpfink.go
@@ -256,7 +256,7 @@ func (instance *BPFinkInstance) ExpectSudoersEvent(t *testing.T, e Event) {
 		return
 	}
 	var record sudoersFileLogRecord
-	if err = json.Unmarshal([]byte(string(line)), &record); err != nil {
+	if err = json.Unmarshal([]byte(line), &record); err != nil {
 		t.Errorf("unable to parse line [%s] as sudoers file log record: %s", line, err)
 		return
 	}
@@ -278,5 +278,4 @@ func (instance *BPFinkInstance) ExpectSudoersEvent(t *testing.T, e Event) {
 	} else if record.User != currentUser.Username {
 		t.Errorf("actual user record [%s] is not equal to expected [%s]", record.User, currentUser.Username)
 	}
-
 }

--- a/e2etests/fs.go
+++ b/e2etests/fs.go
@@ -7,6 +7,7 @@ import (
 
 type FS struct {
 	GenericMonitoringDir string
+	SudoersDir           string
 }
 
 func (fs *FS) MustCreateFile(t *testing.T, filePath string) *os.File {

--- a/e2etests/world.go
+++ b/e2etests/world.go
@@ -41,6 +41,7 @@ func SetUp(t *testing.T) *World {
 		BPFinkEbpfProgramm:   *executionParams.ebpfObjPath,
 		TestRootDir:          filepath.Join(testRootDir),
 		GenericMonitoringDir: filepath.Join(testRootDir, "root"),
+		SudoersDir:           filepath.Join(testRootDir, "sudoers"),
 	}
 
 	bpfink := BPFinkRun(t, bpfinkParams)
@@ -56,6 +57,7 @@ func SetUp(t *testing.T) *World {
 		BPFink: bpfink,
 		FS: &FS{
 			GenericMonitoringDir: bpfinkParams.GenericMonitoringDir,
+			SudoersDir:           bpfinkParams.SudoersDir,
 		},
 	}
 }

--- a/examples/watcher/setup.sh
+++ b/examples/watcher/setup.sh
@@ -54,15 +54,15 @@ _config () {
 	echo "bcc = \"${PROJECT}/pkg/ebpf/vfs.o\"" >> bpfink.toml
 	echo "keyfile = \"\"" >> bpfink.toml
 	cat >> bpfink.toml <<- 'EOF'
-		level = "debug"
+		level = "info"
 		database = "bpfink.db"
 		[consumers]
 	EOF
   echo "root = \"/\"" >>bpfink.toml
 
   echo "access = \"${PROJECT}/examples/watcher/test-dir/bpfink.access\"" >> bpfink.toml
-  echo "generic = [\"${PROJECT}/examples/watcher/test-dir/dynamic-watcher\"]" >> bpfink.toml
-  echo "sudoers = [\"${PROJECT}/examples/watcher/test-dir/bpfink.sudoers\", \"/home/rhasini/sudoers\"]" >> bpfink.toml
+  echo "generic = [\"${PROJECT}/examples/watcher/test-dir/dynamic-watcher\",  \"/etc\"]" >> bpfink.toml
+  echo "sudoers = [\"${PROJECT}/examples/watcher/test-dir/bpfink.sudoers\", \"/etc/sudoers.d\"]" >> bpfink.toml
   echo "excludes = [\"${PROJECT}/examples/watcher/test-dir/dynamic-watcher/exclude-dir\", \"${PROJECT}/examples/watcher/test-dir/excludeFile\"]" >>bpfink.toml
 
   cat >>bpfink.toml <<-'EOF'
@@ -169,7 +169,7 @@ run() {
   clean
   init
   run_test &
-  sudo -E go run "${PROJECT}"/cmd/main.go --config "${PROJECT}"/examples/watcher/test-dir/bpfink.toml
+  sudo go run "${PROJECT}"/cmd/main.go --config "${PROJECT}"/examples/watcher/test-dir/bpfink.toml
   clean
 }
 

--- a/examples/watcher/setup.sh
+++ b/examples/watcher/setup.sh
@@ -44,18 +44,25 @@ _shadow() {
 	EOF
 }
 
-_config() {
-  echo "bcc = \"${PROJECT}/pkg/ebpf/vfs.o\"" >>bpfink.toml
-  echo "keyfile = \"\"" >>bpfink.toml
-  cat >>bpfink.toml <<-'EOF'
-		level = "info"
+_sudoers () {
+	cat > bpfink.sudoers <<- EOF
+		root ALL = (ALL:ALL) ALL
+	EOF
+}
+
+_config () {
+	echo "bcc = \"${PROJECT}/pkg/ebpf/vfs.o\"" >> bpfink.toml
+	echo "keyfile = \"\"" >> bpfink.toml
+	cat >> bpfink.toml <<- 'EOF'
+		level = "debug"
 		database = "bpfink.db"
 		[consumers]
 	EOF
   echo "root = \"/\"" >>bpfink.toml
 
-  echo "access = \"${PROJECT}/examples/watcher/test-dir/bpfink.access\"" >>bpfink.toml
-  echo "generic = [\"${PROJECT}/examples/watcher/test-dir/dynamic-watcher\", \"/etc\"]" >>bpfink.toml
+  echo "access = \"${PROJECT}/examples/watcher/test-dir/bpfink.access\"" >> bpfink.toml
+  echo "generic = [\"${PROJECT}/examples/watcher/test-dir/dynamic-watcher\"]" >> bpfink.toml
+  echo "sudoers = [\"${PROJECT}/examples/watcher/test-dir/bpfink.sudoers\", \"/home/rhasini/sudoers\"]" >> bpfink.toml
   echo "excludes = [\"${PROJECT}/examples/watcher/test-dir/dynamic-watcher/exclude-dir\", \"${PROJECT}/examples/watcher/test-dir/excludeFile\"]" >>bpfink.toml
 
   cat >>bpfink.toml <<-'EOF'
@@ -92,6 +99,7 @@ init() {
   _passwd
   _shadow
   _access
+  _sudoers
   _config
   make -r -C "${PROJECT}/pkg/ebpf" || exit
 }
@@ -124,6 +132,15 @@ run_test() {
   sed -i '$ d' bpfink.shadow
   sleep 2
 
+  ##Sudoers
+  printf "\n\nadding 'ncircle ALL=(ALL) NOPASSWD:NCIRCLE_CMDS' and 'Cmnd_Alias NCIRCLE_CMDS=ALL, !/bin/netstat' to bpfink.sudoers\n\n"
+  echo "ncircle ALL=(ALL) NOPASSWD:NCIRCLE_CMDS" >>bpfink.sudoers
+  echo "Cmnd_Alias NCIRCLE_CMDS=ALL, !/bin/netstat" >>bpfink.sudoers
+  sleep 2
+  printf "\n\nremove last addition\n"
+  sed -i '$ d' bpfink.sudoers
+  sleep 2
+
   printf "\n\ncreate a new file in dynamic-watcher\n\n"
   echo "Real Time file creation" >>dynamic-watcher/dynamic-file.txt
   sleep 2
@@ -152,7 +169,7 @@ run() {
   clean
   init
   run_test &
-  sudo go run "${PROJECT}"/cmd/main.go --config "${PROJECT}"/examples/watcher/test-dir/bpfink.toml
+  sudo -E go run "${PROJECT}"/cmd/main.go --config "${PROJECT}"/examples/watcher/test-dir/bpfink.toml
   clean
 }
 

--- a/pkg/consumers.go
+++ b/pkg/consumers.go
@@ -334,6 +334,73 @@ func (gs *GenericState) Load(db *AgentDB) error {
 	return err
 }
 
+/* --------------------------------- SUDOERS --------------------------------- */
+type (
+	//SudoersState struct keeps track of state changes based on SudoersListener struct and methods
+	SudoersState struct {
+		*SudoersListener
+		current, next Sudoers
+	}
+)
+
+//Parse calls parse(), and update new SudoersState
+func (ss *SudoersState) Parse() (State, error) {
+	sudoers, err := ss.parse()
+	if err != nil {
+		return nil, err
+	}
+	ss.next = sudoers
+	return ss, nil
+}
+
+//Changed checks if the new SudoersState instance is different from old SudoersState instance
+func (ss *SudoersState) Changed() bool {
+	add, del := sudoersDiff(ss.current, ss.next)
+	return !add.IsEmpty() || !del.IsEmpty()
+}
+
+//Created checks if the current SudoersState has been created
+func (ss *SudoersState) Created() bool { return ss.current.IsEmpty() }
+
+//Notify is the method to notify of a change in state
+func (ss *SudoersState) Notify(cmd string, user string) {
+	add, del := sudoersDiff(ss.current, ss.next)
+	ss.Warn().
+		Object("add", LogSudoers(add)).
+		Object("del", LogSudoers(del)).
+		Str("file", ss.sudoers).
+		Str("processName", cmd).
+		Str("user", user).
+		Msg("Sudoers Modified")
+}
+
+//Teardown is the reset method when a change has been detected. Set new state to old state, and reload.
+func (ss *SudoersState) Teardown() error {
+	ss.current = ss.next
+	return nil
+}
+
+//Register returns a list of files to watch for changes
+func (ss *SudoersState) Register() []string {
+	return ss.SudoersListener.Register()
+}
+
+//Save commits a state to the local DB instance.
+func (ss *SudoersState) Save(db *AgentDB) error {
+	ss.Debug().Object("sudoers", LogSudoers(ss.next)).Msg("Save sudoers file")
+	return db.SaveSudoers(ss.next)
+}
+
+//Load reads in current state from local db instance
+func (ss *SudoersState) Load(db *AgentDB) (err error) {
+	sudoers, err := db.LoadSudoers()
+	if err != nil {
+		return err
+	}
+	ss.current = sudoers
+	return err
+}
+
 /* ------------------------------ NOP CONSUMER ------------------------------ */
 type nopConsumer struct{}
 

--- a/pkg/db.go
+++ b/pkg/db.go
@@ -18,6 +18,7 @@ const (
 	usersKey   = "users"
 	accessKey  = "access"
 	genericKey = "generic"
+	sudoersKey = "sudoers"
 )
 
 func (a *AgentDB) save(k string, v interface{}) error {
@@ -63,7 +64,10 @@ func (a *AgentDB) SaveAccess(access Access) error { return a.save(accessKey, acc
 // SaveGeneric method to save generic files
 func (a *AgentDB) SaveGeneric(generic Generic) error { return a.save(genericKey, generic) }
 
-// LoadUsers method to load users
+//SaveSudoers method to save sudoers
+func (a *AgentDB) SaveSudoers(sudoers Sudoers) error { return a.save(sudoersKey, sudoers) }
+
+//LoadUsers method to load users
 func (a *AgentDB) LoadUsers() (Users, error) {
 	users := Users{}
 	return users, a.load(usersKey, &users)
@@ -79,4 +83,10 @@ func (a *AgentDB) LoadAccess() (Access, error) {
 func (a *AgentDB) LoadGeneric() (Generic, error) {
 	generic := Generic{}
 	return generic, a.load(genericKey, &generic)
+}
+
+//LoadUsers method to load users
+func (a *AgentDB) LoadSudoers() (Sudoers, error) {
+	sudoers := Sudoers{}
+	return sudoers, a.load(sudoersKey, &sudoers)
 }

--- a/pkg/lang/sudoers/parser.go
+++ b/pkg/lang/sudoers/parser.go
@@ -1,0 +1,49 @@
+package sudoers
+
+import (
+	"bufio"
+	"os"
+
+	"github.com/rs/zerolog"
+)
+
+//Sudoer struct that represents permission in the suoders file
+type Sudoer struct {
+	Rule string
+}
+
+//Parser struct to handle parsing of sudoers file
+type Parser struct {
+	zerolog.Logger
+	FileName string
+	Sudoers  []Sudoer
+}
+
+//Parse func that parses a passwd file to collect users
+func (p *Parser) Parse() error {
+	file, err := os.Open(p.FileName)
+	if err != nil {
+		p.Error().Err(err)
+		return err
+	}
+	defer func() {
+		if err := file.Close(); err != nil {
+			p.Error().Err(err)
+		}
+	}()
+
+	scanner := bufio.NewScanner(file)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if len(line) == 0 || string(line[0]) == "#" {
+			continue
+		}
+		p.Logger.Debug().Msgf(" Sudoers entries are %v", line)
+
+		p.Sudoers = append(p.Sudoers, Sudoer{
+			Rule: line,
+		})
+	}
+	return nil
+}

--- a/pkg/lang/sudoers/parser.go
+++ b/pkg/lang/sudoers/parser.go
@@ -31,16 +31,24 @@ func (p *Parser) Parse() error {
 			p.Error().Err(err)
 		}
 	}()
+	// If the file is empty
+	stat, err := file.Stat()
+	if err != nil {
+		return err
+	}
 
+	if stat.Size() == 0 {
+		p.Sudoers = append(p.Sudoers, Sudoer{
+			Rule: " ",
+		})
+	}
 	scanner := bufio.NewScanner(file)
-
 	for scanner.Scan() {
 		line := scanner.Text()
 		if len(line) == 0 || string(line[0]) == "#" {
 			continue
 		}
-		p.Logger.Debug().Msgf(" Sudoers entries are %v", line)
-
+		p.Logger.Debug().Msgf("Sudoers entries are %v", line)
 		p.Sudoers = append(p.Sudoers, Sudoer{
 			Rule: line,
 		})

--- a/pkg/logs.go
+++ b/pkg/logs.go
@@ -19,6 +19,8 @@ type (
 	LogAccess Access
 	// LogGeneric type wrapper
 	LogGeneric GenericState
+	//LogSudoers type wrapper
+	LogSudoers Sudoers
 )
 
 // MarshalZerologObject method to wrap a logger
@@ -65,8 +67,13 @@ func (la LogAccess) MarshalZerologObject(e *zerolog.Event) {
 	e.Strs("deny", la.Deny)
 }
 
-// MarshalZerologObject method to marshal access object
+// MarshalZerologObject method to marshal generic object
 func (lg LogGeneric) MarshalZerologObject(e *zerolog.Event) {
 	e.Hex("current", lg.current.Contents)
 	e.Hex("next", lg.next.Contents) // update to aes-gcm
+}
+
+//MarshalZerologObject method to marshal sudoers object
+func (ls LogSudoers) MarshalZerologObject(e *zerolog.Event) {
+	e.Strs("Sudoers", ls.Rule)
 }

--- a/pkg/sudoers.go
+++ b/pkg/sudoers.go
@@ -1,0 +1,86 @@
+package pkg
+
+import (
+	"github.com/bookingcom/bpfink/pkg/lang/sudoers"
+	"github.com/rs/zerolog"
+	"github.com/spf13/afero"
+)
+
+type (
+	//Sudoers struct used to store changes to the sudoers file
+	Sudoers struct {
+		Rule []string
+	}
+
+	//SudoersListener struct used for filestream events.
+	SudoersListener struct {
+		zerolog.Logger
+		afero.Fs
+		sudoers string
+	}
+
+	sudoersListener struct {
+		Sudoers
+		zerolog.Logger
+	}
+)
+
+func sudoersDiff(old, new Sudoers) (add, del Sudoers) {
+	add, del = Sudoers{}, Sudoers{}
+	add.Rule, del.Rule = ArrayDiff(old.Rule, new.Rule)
+	return
+}
+
+//IsEmpty method to check if diff is empty
+func (s Sudoers) IsEmpty() bool { return len(s.Rule) == 0 }
+
+//SudoersFileOpt function used to return metadata on a file
+func SudoersFileOpt(fs afero.Fs, path string, logger zerolog.Logger) func(*SudoersListener) {
+	return func(listener *SudoersListener) {
+		listener.sudoers = path
+		listener.Logger = logger
+		listener.Fs = fs
+	}
+}
+
+//NewSudoersListener function to create a new file event listener
+func NewSudoersListener(options ...func(*SudoersListener)) *SudoersListener {
+	sl := &SudoersListener{Logger: zerolog.Nop()}
+	for _, option := range options {
+		option(sl)
+	}
+	return sl
+}
+
+func (sl *SudoersListener) parse() (Sudoers, error) {
+	listener := &sudoersListener{Logger: sl.Logger}
+	sl.Debug().Msgf("parsing sudoers: %v", sl.sudoers)
+
+	err := listener.sudoersParse(sl.sudoers)
+	if err != nil {
+		return Sudoers{}, err
+	}
+	return listener.Sudoers, nil
+}
+
+func (sl *sudoersListener) sudoersParse(fileName string) error {
+	sudoersData := sudoers.Parser{FileName: fileName, Logger: sl.Logger}
+	sl.Debug().Msg("parsing sudoers file")
+	err := sudoersData.Parse()
+	if err != nil {
+		return err
+	}
+	for _, sudoersdata := range sudoersData.Sudoers {
+		sl.Sudoers.Rule = append(sl.Sudoers.Rule, sudoersdata.Rule)
+	}
+	return nil
+}
+
+//Register method returns list of paths to files to be watched
+func (sl *SudoersListener) Register() []string {
+	if base, ok := sl.Fs.(*afero.BasePathFs); ok {
+		path, _ := base.RealPath(sl.sudoers)
+		return []string{path}
+	}
+	return []string{sl.sudoers}
+}


### PR DESCRIPTION
* Adding a new consumer to parse sudoers files.
* Files included - /etc/sudoers and all files under /etc/sudoers.d directory.
* Implemented test cases for sudoers