### PR TITLE
Send version of bpfink as metric and in each log entry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 BINARY = bpfink
-LD_FLAGS ?= -w -s -X main.BuildDate=$(shell date +%F)
+LD_FLAGS ?= -w -s -X main.BuildDate=$(shell date +%F) -X main.Version=$(BINARY_VERSION)
 PREFIX ?= /usr
+BINARY_VERSION ?=
 
 all: build
 build: $(BINARY)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,6 +25,7 @@ import (
 // nolint:gochecknoglobals
 var (
 	BuildDate          = "(development)"
+	Version            string
 	MetricsInitialised struct {
 		metrics *pkg.Metrics
 		err     error
@@ -82,7 +83,10 @@ const (
 
 // LogHook to send a graphite metric for each log entry
 func (h LogHook) Run(e *zerolog.Event, level zerolog.Level, msg string) {
+	// Send log type metric
 	h.metric.RecordByLogTypes(level.String())
+	// Send version in each log entry
+	e.Str("version", Version)
 }
 
 func (c Configuration) logger() (logger zerolog.Logger) {
@@ -426,6 +430,8 @@ func run() error {
 
 	// increment the host count by 1
 	metrics.RecordByInstalledHost()
+	// send version metric
+	metrics.RecordVersion(Version)
 	err = metrics.RecordBPFMetrics()
 	if err != nil {
 		logger.Fatal().Err(err).Msg("error starting bpf metrics")

--- a/pkg/graphite.go
+++ b/pkg/graphite.go
@@ -96,6 +96,18 @@ func (m *Metrics) RecordByEventsCaught() {
 	goMetrics.GetOrRegisterCounter(metricName, m.EveryMinuteRegister).Inc(1)
 }
 
+// RecordVersion graphite metric to show the version of bpfink running on each host
+func (m *Metrics) RecordVersion(version string) {
+	// If rolename is not empty, override the defaultRolename
+	if m.RoleName != "" {
+		defaultRolename = m.RoleName
+	}
+
+	versionInt, _ := strconv.ParseInt(strings.Replace(version, ".", "", -1), 10, 64)
+	metricName := fmt.Sprintf("installed.by_role.%s.%s.version.hourly", quote(defaultRolename), quote(m.Hostname))
+	goMetrics.GetOrRegisterGauge(metricName, m.EveryHourRegister).Update(versionInt)
+}
+
 // RecordByInstalledHost graphite metric to show how manay host have bpfink installed
 func (m *Metrics) RecordByInstalledHost() {
 	// If rolename is not empty, override the defaultRolename

--- a/pkg/graphite_test.go
+++ b/pkg/graphite_test.go
@@ -49,6 +49,16 @@ func TestEventsCaughtMetric(t *testing.T) {
 	})
 }
 
+func TestVersionMetric(t *testing.T) {
+	m := InitMetrics()
+	defer m.EveryHourRegister.UnregisterAll()
+	m.RecordVersion("0.1.12")
+
+	testIfMetricsAreExpected(t, m.EveryHourRegister, map[string]float64{
+		"security.piv.bpfink.installed.by_role.unknown_role.test_host.version.hourly": 112,
+	})
+}
+
 func testIfMetricsAreExpected(t *testing.T, registry goMetrics.Registry, expectedMetrics map[string]float64) {
 	actualMetrics := registry.GetAll()
 	if len(expectedMetrics) != len(actualMetrics) {


### PR DESCRIPTION
While building the program, passing BINARY_VERSION with the version of bpfink will provide the version in all logs and send a metric to graphite with the int64 value of the version as metric value.