### PR TITLE
Send correct hit rate metric when no events have occurred

### DIFF
--- a/pkg/graphite.go
+++ b/pkg/graphite.go
@@ -238,11 +238,13 @@ func (m *Metrics) parseBPFLine(tokens []string, probeName string) (*bpfMetrics, 
 	m.missedCount[probeName] = currentMiss
 	m.mux.Unlock()
 	// Send hit/miss rates instead of value
-	hitRate = float64(hitValue)
-	missedRate = float64(missedValue)
 	if hitValue != 0 || missedValue != 0 {
 		hitRate = float64(hitValue) / float64(hitValue+missedValue)
 		missedRate = float64(missedValue) / float64(hitValue+missedValue)
+	} else {
+		// Hit/Miss rates are 0, meaning no new events occurred, send hitRate 1
+		hitRate = float64(1)
+		missedRate = float64(missedValue)
 	}
 	return &bpfMetrics{
 		hitRate:    hitRate,


### PR DESCRIPTION
Currently when no new events have occurred, hit/miss values are 0 and we send 0 as the metric, which is treated as bad. Updating this to send a hitRate of 1 when no events have occurred.