### PR TITLE
Wildcard path support for generic[diff] consumers

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -31,7 +31,6 @@ var (
 		err     error
 		Once    sync.Once
 	}
-	GenericDiffPaths []string
 )
 
 type (
@@ -117,7 +116,10 @@ func (c Configuration) logger() (logger zerolog.Logger) {
 	return logger
 }
 
-func (c Configuration) consumers(db *pkg.AgentDB) (consumers pkg.BaseConsumers) {
+/*
+Initialises all the consumers along with pre-populating genericDiffPaths used by watcher
+*/
+func (c Configuration) consumers(db *pkg.AgentDB, genericDiffPaths *[]string) (consumers pkg.BaseConsumers) {
 	fs := afero.NewOsFs()
 	var existingConsumersFiles = make(map[string]bool)
 
@@ -162,7 +164,7 @@ func (c Configuration) consumers(db *pkg.AgentDB) (consumers pkg.BaseConsumers) 
 				consumers = append(consumers, &pkg.BaseConsumer{AgentDB: db, ParserLoader: state})
 				existingConsumersFiles[genericDiffFile.File] = true
 				//this variable is used by watcher to get the complete list of paths to monitor, instead of the list from the config
-				GenericDiffPaths = append(GenericDiffPaths, genericDiffFile.File)
+				*genericDiffPaths = append(*genericDiffPaths, genericDiffFile.File)
 			}
 		}
 	}
@@ -214,6 +216,7 @@ func (c Configuration) getCompleteListOfPaths(pathList []string) []string {
 		completePath, err := filepath.Glob(path)
 		if err != nil {
 			logger.Error().Err(err).Msgf("Error getting complete list of paths to register: %v", err)
+			continue
 		}
 		completePathList = append(completePathList, completePath...)
 	}
@@ -372,6 +375,7 @@ func (c Configuration) metrics() (*pkg.Metrics, error) {
 
 func (c Configuration) watcher() (*pkg.Watcher, error) {
 	logger := c.logger()
+	var genericDiffPaths []string
 	logger.Debug().Str("db", c.Database).Msg("opening bolt database")
 	db, err := bolt.Open(c.Database, 0600, nil)
 	if err != nil {
@@ -384,7 +388,7 @@ func (c Configuration) watcher() (*pkg.Watcher, error) {
 	}
 
 	database := &pkg.AgentDB{Logger: logger, DB: db}
-	consumers := c.consumers(database)
+	consumers := c.consumers(database, &genericDiffPaths)
 
 	for _, consumer := range consumers {
 		if err := consumer.Init(); err != nil {
@@ -392,7 +396,7 @@ func (c Configuration) watcher() (*pkg.Watcher, error) {
 		}
 	}
 	return pkg.NewWatcher(func(w *pkg.Watcher) {
-		w.Logger, w.Consumers, w.FIM, w.Database, w.Key, w.Excludes, w.GenericDiff = logger, consumers.Consumers(), fim, database, c.key, c.Consumers.Excludes, GenericDiffPaths
+		w.Logger, w.Consumers, w.FIM, w.Database, w.Key, w.Excludes, w.GenericDiff = logger, consumers.Consumers(), fim, database, c.key, c.Consumers.Excludes, genericDiffPaths
 	}), nil
 }
 


### PR DESCRIPTION
Currently, BPFink generic[diff] consumers only monitor full paths of files/dirs. Including support for wildcards paths to be monitored.
```
Ex config: [genericdiff] = "/etc/resolv.conf", "/home/*/.ssh", "/home/*/.bash_profile"
```